### PR TITLE
Install rls rather than rls-preview

### DIFF
--- a/TabNine.toml
+++ b/TabNine.toml
@@ -2,7 +2,7 @@
 command = "rls"
 install = [
   ["rustup", "update"],
-  ["rustup", "component", "add", "rls-preview", "rust-analysis", "rust-src"],
+  ["rustup", "component", "add", "rls", "rust-analysis", "rust-src"],
 ]
 
 [language.javascript]


### PR DESCRIPTION
The instructions in the [RLS repository](https://github.com/rust-lang/rls) have changed to suggest installing rls instead of rls-preview:

> Once you have rustup installed, run the following commands:
>
>     rustup component add rls rust-analysis rust-src