### PR TITLE
Associate `Jupyter` with python programming language.

### DIFF
--- a/languages.yml
+++ b/languages.yml
@@ -2170,8 +2170,9 @@ Julia:
   codemirror_mime_type: text/x-julia
   language_id: 184
 Jupyter Notebook:
-  type: markup
-  ace_mode: json
+  type: programming
+  group: Python
+  ace_mode: python
   codemirror_mode: javascript
   codemirror_mime_type: application/json
   tm_scope: source.json
@@ -3603,6 +3604,7 @@ Python:
   - wscript
   interpreters:
   - python
+  - ipython
   - python2
   - python3
   aliases:


### PR DESCRIPTION
So currently jupyter is not associated with python or any other programming language. The `jupyter-tabnine` extension work arounds this by [renaming the caller as .py file](https://github.com/codota/jupyter-tabnine/blob/master/src/jupyter_tabnine/tabnine.py#L68). 

Now that jupyter is also [natively supported by vscode](https://github.com/codota/tabnine-vscode/issues/61) we need to address it more generally to get the same behavior. 

And also notice that 3rd party clients would normally register for [python completions](https://github.com/microsoft/vscode-jupyter/blob/bfe2f544d2a518ceb9fab194cdd0bb7463cd3673/src/client/datascience/notebook/integration.ts#L96) in notebook code cells.