### PR TITLE
Add support for the new .mts and .cts file extensions.

### DIFF
--- a/languages.yml
+++ b/languages.yml
@@ -4689,6 +4689,8 @@ TypeScript:
   extensions:
   - ".ts"
   - ".tsx"
+  - ".mts"
+  - ".cts"
   tm_scope: source.ts
   ace_mode: typescript
   codemirror_mode: javascript


### PR DESCRIPTION
.mts and .cts are now valid file extensions for TypeScript, added in https://github.com/microsoft/TypeScript/pull/45884.

This PR adds them as supported extensions, and treats them as regular TypeScript files.