### PR TITLE
COBOL identifier with hyphen

### DIFF
--- a/language_tokenization.json
+++ b/language_tokenization.json
@@ -27,6 +27,9 @@
     "lsp_id": "tex" 
   },
   "Clojure": { "lsp_id": "clojure" },
+  "COBOL": {
+    "add_identifier_chars": "-"
+  },
   "CoffeeScript":  { "lsp_id": "coffeescript" },
   "C/C++": { "lsp_id": "cpp" },
   "C#":  { "lsp_id": "csharp" },


### PR DESCRIPTION
It would be quite cool to see if Tabnine can handle COBOL with its non-local identifier definitions...