### PR TITLE
feat(python): Add .pyz and .pyzw extensions for Python

### DIFF
--- a/languages.yml
+++ b/languages.yml
@@ -3587,6 +3587,8 @@ Python:
   - ".pyp"
   - ".pyt"
   - ".pyw"
+  - ".pyz"
+  - ".pyzw"
   - ".rpy"
   - ".spec"
   - ".tac"


### PR DESCRIPTION
This pull request adds the '.pyz' and '.pyzw' file extensions to the Python language definition in 'languages.yml'.

These extensions are used for Python zip applications, as described in [PEP 441](https://www.python.org/dev/peps/pep-0441/). Including them in the language definition will allow TabNine to correctly identify these files as Python code, thus improving the autocompletion experience for developers working with such files.